### PR TITLE
Add BLE advertising CBOR parsing

### DIFF
--- a/BLE/Protocol.cpp
+++ b/BLE/Protocol.cpp
@@ -1,6 +1,7 @@
 #include "Protocol.hpp"
-#include "ossia/network/base/node.hpp"
-#include "ossia/network/base/node_functions.hpp"
+
+#include <ossia/network/base/node.hpp>
+#include <ossia/network/base/node_functions.hpp>
 
 #include <ossia/detail/config.hpp>
 
@@ -25,7 +26,7 @@ void expose_manufacturer_data_as_ossia_nodes(
     ossia::net::node_base& device_node,
     const std::map<uint16_t, SimpleBLE::ByteArray>& manufacturer_data)
 {
-  for(auto [id, data] : manufacturer_data)
+  for(const auto& [id, data] : manufacturer_data)
   {
     bool got_good_cbor = false;
     // If the id is the special BLE CBOR id, we have a special advertisement containing CBOR data

--- a/BLE/Protocol.hpp
+++ b/BLE/Protocol.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "simpleble/Types.h"
 #include <ossia/network/base/protocol.hpp>
 #include <ossia/network/context.hpp>
 #include <ossia/network/context_functions.hpp>
@@ -6,6 +7,8 @@
 #include <boost/container/flat_map.hpp>
 
 #include <simpleble/SimpleBLE.h>
+#include <cstdint>
+#include <QCborStreamReader>
 
 namespace ossia::net
 {
@@ -13,6 +16,32 @@ namespace ossia::net
 }
 namespace ossia
 {
+
+/**
+ * This id denotes a special manufacturer data that we knwo should contain CBOR encoded data.
+ */
+constexpr int special_ble_cbor_id = 0xffff;
+
+/**
+ * Expose the manufacturer data found in BLE advertisements as child nodes of device_node.
+ * This will call expose_cbor_as_ossia_nodes if it detects the special_ble_cbor_id.
+ */
+void expose_manufacturer_data_as_ossia_nodes(ossia::net::node_base& device_node, const std::map<uint16_t, SimpleBLE::ByteArray>& manufacturer_data);
+
+/**
+ * basically qt's CBOR string reading example. could be replaced by a readAllString() call in qt 6.7 but I'm developing with qt 6.2.
+ * returns a QString with the content or an empty QString if there was an error.
+ */
+QString read_next_cbor_string(QCborStreamReader& reader);
+
+/**
+ * Tries to parse the manufacturer data bytes as a subset of CBOR and expose the values as nodes.
+ * The supported subset of CBOR is a single map with string keys and float|double|int|bool|string values.
+ * Returns false if there was an error.
+ *
+ * In case of error, this may still expose some of the data if there was valid data to expose.
+ */
+bool expose_cbor_as_ossia_nodes(ossia::net::node_base& device_node, const SimpleBLE::ByteArray& cbor_data);
 
 class OSSIA_EXPORT ble_protocol final : public ossia::net::protocol_base
 {


### PR DESCRIPTION
This adds CBOR data parsing for BLE advertisements that declare their manufacturer id to be `0xFFFF`. If the advertisement didn't contain valid CBOR data after all, this will still expose the raw bytes as with other manufacturer data.